### PR TITLE
Fix publisher initialization error and refactor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ROS2 for .NET
 =============
 
+[![CircleCI](https://circleci.com/gh/samiamlabs/ros2_dotnet/tree/dashing.svg?style=svg)](https://circleci.com/gh/samiamlabs/ros2_dotnet/tree/dashing)
+
 TODO - update README. This works a bit for Dashing now - examples of talker and listener and message generation. (lots to do still)
 
 Most important Issues 

--- a/rcldotnet/NativeMethods.cs
+++ b/rcldotnet/NativeMethods.cs
@@ -171,7 +171,7 @@ namespace rclcs
 
         // rcl_publisher_init
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        internal delegate int PublisherInitType(ref rcl_publisher_t publisher, ref rcl_node_t node, IntPtr type_support_ptr, string topic_name, ref rcl_publisher_options_t publisher_options);
+        internal delegate int PublisherInitType(ref rcl_publisher_t publisher, ref rcl_node_t node, IntPtr type_support_ptr, string topic_name, IntPtr publisher_options);
         internal static PublisherInitType
             rcl_publisher_init =
             (PublisherInitType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
@@ -418,6 +418,26 @@ namespace rclcs
             nativeRclcs,
             "rclcs_subscription_dispose_options"),
             typeof(SubscriptionDisposeOptionsType));
+
+        // rclcs_publisher_create_default_options
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate IntPtr PublisherCreateDefaultOptionsType();
+        internal static PublisherCreateDefaultOptionsType
+            rclcs_publisher_create_default_options =
+            (PublisherCreateDefaultOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+            nativeRclcs,
+            "rclcs_publisher_create_default_options"),
+            typeof(PublisherCreateDefaultOptionsType));
+
+        // rclcs_publisher_dispose_options
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        internal delegate void PublisherDisposeOptionsType(IntPtr options);
+        internal static PublisherDisposeOptionsType
+            rclcs_publisher_dispose_options =
+            (PublisherDisposeOptionsType)Marshal.GetDelegateForFunctionPointer(dllLoadUtils.GetProcAddress(
+            nativeRclcs,
+            "rclcs_publisher_dispose_options"),
+            typeof(PublisherDisposeOptionsType));
 
         // rclcs_subscription_set_qos_profile
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/rcldotnet/Publisher.cs
+++ b/rcldotnet/Publisher.cs
@@ -26,13 +26,15 @@ namespace rclcs
         rcl_publisher_t handle;
         rcl_node_t nodeHandle;
 
+        private IntPtr publisherOptions = new IntPtr();
+
         private bool disposed;
 
         public Publisher(string topic, Node node)
         {
             nodeHandle = node.handle;
             handle = NativeMethods.rcl_get_zero_initialized_publisher();
-            rcl_publisher_options_t publisherOptions = NativeMethods.rcl_publisher_get_default_options();
+            IntPtr publisherOptions = NativeMethods.rclcs_publisher_create_default_options();
             //TODO(samiam): Figure out why System.Reflection is not available 
             //when building with colcon/xtool on ubuntu 18.04 and mono 4.5
 
@@ -46,7 +48,7 @@ namespace rclcs
                                     ref nodeHandle, 
                                     typeSupportHandle, 
                                     topic,
-                                    ref publisherOptions));
+                                    publisherOptions));
         }
 
         ~Publisher()
@@ -78,6 +80,7 @@ namespace rclcs
         private void DestroyPublisher()
         {
             Utils.CheckReturnEnum(NativeMethods.rcl_publisher_fini(ref handle, ref nodeHandle));
+            NativeMethods.rclcs_publisher_dispose_options(publisherOptions);
         }
 
 

--- a/rcldotnet/_rclcs.c
+++ b/rcldotnet/_rclcs.c
@@ -68,6 +68,20 @@ void rclcs_subscription_dispose_options(rcl_subscription_options_t * subscriptio
 }
 
 ROSIDL_GENERATOR_C_EXPORT
+rcl_publisher_options_t * rclcs_publisher_create_default_options()
+{
+  rcl_publisher_options_t  * default_publisher_options_handle = (rcl_publisher_options_t *)malloc(sizeof(rcl_publisher_options_t));
+  *default_publisher_options_handle = rcl_publisher_get_default_options();
+  return default_publisher_options_handle;
+}
+
+ROSIDL_GENERATOR_C_EXPORT
+void rclcs_publisher_dispose_options(rcl_publisher_options_t * publisher_options_handle)
+{
+  free(publisher_options_handle);
+}
+
+ROSIDL_GENERATOR_C_EXPORT
 char * rclcs_get_error_string()
 {
   rcl_error_string_t error_string = rcl_get_error_string();

--- a/rcldotnet_tests/NativeMetodsTest.cs
+++ b/rcldotnet_tests/NativeMetodsTest.cs
@@ -261,30 +261,31 @@ namespace rclcs.TestNativeMethods
             rcl_publisher_t publisher = NativeMethods.rcl_get_zero_initialized_publisher();
         }
 
-        public static void InitPublisher(ref rcl_publisher_t publisher, ref rcl_node_t node)
+        public static void InitPublisher(ref rcl_publisher_t publisher, ref rcl_node_t node, IntPtr publisherOptions)
         {
             RCLReturnEnum ret;
             publisher = NativeMethods.rcl_get_zero_initialized_publisher();
-            rcl_publisher_options_t publisherOptions = NativeMethods.rcl_publisher_get_default_options();
+            publisherOptions = NativeMethods.rclcs_publisher_create_default_options();
             IRclcsMessage msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
-            ret = (RCLReturnEnum)NativeMethods.rcl_publisher_init(ref publisher, ref node, typeSupportHandle, "publisher_test_topic", ref publisherOptions);
-            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+            ret = (RCLReturnEnum)NativeMethods.rcl_publisher_init(ref publisher, ref node, typeSupportHandle, "publisher_test_topic", publisherOptions);
         }
 
-        public static void ShutdownPublisher(ref rcl_publisher_t publisher, ref rcl_node_t node)
+        public static void ShutdownPublisher(ref rcl_publisher_t publisher, ref rcl_node_t node, IntPtr publisherOptions)
         {
             RCLReturnEnum ret;
             ret = (RCLReturnEnum)NativeMethods.rcl_publisher_fini(ref publisher, ref node);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+            NativeMethods.rclcs_publisher_dispose_options(publisherOptions);
         }
 
         [Test]
         public void PublisherInit()
         {
             rcl_publisher_t publisher = new rcl_publisher_t();
-            InitPublisher(ref publisher, ref node);
-            ShutdownPublisher(ref publisher, ref node);
+            IntPtr publisherOptions = new IntPtr();
+            InitPublisher(ref publisher, ref node, publisherOptions);
+            ShutdownPublisher(ref publisher, ref node, publisherOptions);
 
         } 
     }
@@ -315,11 +316,12 @@ namespace rclcs.TestNativeMethods
         {
             RCLReturnEnum ret;
             rcl_publisher_t publisher = new rcl_publisher_t();
-            PublisherInitialize.InitPublisher(ref publisher, ref node);
+            IntPtr publisherOptions = new IntPtr();
+            PublisherInitialize.InitPublisher(ref publisher, ref node, publisherOptions);
             IRclcsMessage msg = new std_msgs.msg.Bool();
             ret = (RCLReturnEnum)NativeMethods.rcl_publish(ref publisher, msg.Handle);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
-            PublisherInitialize.ShutdownPublisher(ref publisher, ref node);
+            PublisherInitialize.ShutdownPublisher(ref publisher, ref node, publisherOptions);
 
         }
     }

--- a/rcldotnet_tests/NativeMetodsTest.cs
+++ b/rcldotnet_tests/NativeMetodsTest.cs
@@ -14,8 +14,7 @@ namespace rclcs.TestNativeMethods
     [TestFixture]
     public class RCLInitialize
     {
-        [Test]
-        public void InitShutdownFinalize()
+        public static void InitRcl(ref rcl_context_t context)
         {
             RCLReturnEnum ret;
             NativeMethods.rcl_reset_error();
@@ -24,44 +23,49 @@ namespace rclcs.TestNativeMethods
             ret = (RCLReturnEnum)NativeMethods.rcl_init_options_init(ref init_options, allocator);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
 
-            rcl_context_t context = NativeMethods.rcl_get_zero_initialized_context();
+            context = NativeMethods.rcl_get_zero_initialized_context();
 
             ret = (RCLReturnEnum)NativeMethods.rcl_init(0, null, ref init_options, ref context);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
 
             Assert.That(NativeMethods.rcl_context_is_valid(ref context), Is.True);
+            
+        }
+
+        public static void ShutdownRcl(ref rcl_context_t context)
+        {
+            RCLReturnEnum ret;
             ret = (RCLReturnEnum)NativeMethods.rcl_shutdown(ref context);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
 
             ret = (RCLReturnEnum)NativeMethods.rcl_context_fini(ref context);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
         }
+
+        [Test]
+        public void InitShutdownFinalize()
+        {
+            rcl_context_t context = new rcl_context_t();
+            InitRcl(ref context);
+            ShutdownRcl(ref context);
+        }
     }
 
     [TestFixture]
     public class RCL
     {
-        rcl_context_t context;
+        rcl_context_t context = new rcl_context_t();
 
         [SetUp]
         public void SetUp()
         {
-            RCLReturnEnum ret;
-            NativeMethods.rcl_reset_error();
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            ret = (RCLReturnEnum)NativeMethods.rcl_init_options_init(ref init_options, allocator);
-
-            context = NativeMethods.rcl_get_zero_initialized_context();
-
-            ret = (RCLReturnEnum)NativeMethods.rcl_init(0, null, ref init_options, ref context);
+            RCLInitialize.InitRcl(ref context);
         }
 
         [TearDown]
         public void TearDown()
         {
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            RCLInitialize.ShutdownRcl(ref context);
         }
 
         [Test]
@@ -130,6 +134,20 @@ namespace rclcs.TestNativeMethods
     [TestFixture]
     public class NodeInitialize
     {
+        rcl_context_t context = new rcl_context_t();
+
+        [SetUp]
+        public void SetUp()
+        {
+            RCLInitialize.InitRcl(ref context);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            RCLInitialize.ShutdownRcl(ref context);
+        }
+
         [Test]
         public void GetZeroInitializedNode()
         {
@@ -143,29 +161,32 @@ namespace rclcs.TestNativeMethods
             NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
         }
 
-        [Test]
-        public void NodeInit()
+        public static void InitNode(ref rcl_node_t node, IntPtr nodeOptions, ref rcl_context_t context)
         {
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            rcl_context_t context = NativeMethods.rcl_get_zero_initialized_context();
+            node = NativeMethods.rcl_get_zero_initialized_node();
 
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-
-            rcl_node_t node = NativeMethods.rcl_get_zero_initialized_node();
-
-            IntPtr defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
+            nodeOptions = NativeMethods.rclcs_node_create_default_options();
             string name = "node_test";
             string nodeNamespace = "/ns";
 
-            RCLReturnEnum ret = (RCLReturnEnum)NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, defaultNodeOptions);
+            RCLReturnEnum ret = (RCLReturnEnum)NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, nodeOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
-
+        }
+        
+        public static void ShutdownNode(ref rcl_node_t node, IntPtr nodeOptions)
+        {
             NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NativeMethods.rclcs_node_dispose_options(nodeOptions);
+        }
+
+        [Test]
+        public void NodeInitShutdown()
+        {
+            rcl_node_t node = new rcl_node_t();
+            IntPtr nodeOptions = new IntPtr();
+
+            InitNode(ref node, nodeOptions, ref context);
+            ShutdownNode(ref node, nodeOptions);
         }
 
     }
@@ -175,32 +196,20 @@ namespace rclcs.TestNativeMethods
     {
         rcl_context_t context;
         rcl_node_t node;
-        IntPtr defaultNodeOptions;
+        IntPtr nodeOptions = new IntPtr();
 
         [SetUp]
         public void SetUp()
         {
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-
-            node = NativeMethods.rcl_get_zero_initialized_node();
-            defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-
-            string nodeName = "node_test";
-            string nodeNamespace = "/ns";
-            RCLReturnEnum ret = (RCLReturnEnum)NativeMethods.rcl_node_init(ref node, nodeName, nodeNamespace, ref context, defaultNodeOptions);
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
         }
 
         [TearDown]
         public void TearDown()
         {
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
 
         [Test]
@@ -222,6 +231,24 @@ namespace rclcs.TestNativeMethods
     [TestFixture]
     public class PublisherInitialize
     {
+        rcl_context_t context;
+        rcl_node_t node;
+        IntPtr nodeOptions = new IntPtr();
+
+        [SetUp]
+        public void SetUp()
+        {
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
+        }
+
         [Test]
         public void PublisherGetDefaultOptions()
         {
@@ -234,40 +261,32 @@ namespace rclcs.TestNativeMethods
             rcl_publisher_t publisher = NativeMethods.rcl_get_zero_initialized_publisher();
         }
 
-        // FIXME(sam): Figure out why this fails and restore
-        /*         
-        [Test]
-        public void PublisherInit()
+        public static void InitPublisher(ref rcl_publisher_t publisher, ref rcl_node_t node)
         {
-            // init 
             RCLReturnEnum ret;
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            rcl_context_t context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-            rcl_node_t node = NativeMethods.rcl_get_zero_initialized_node();
-            string name = "publisher_test";
-            string nodeNamespace = "/ns";
-            IntPtr defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-            NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, defaultNodeOptions);
-
-            rcl_publisher_t publisher = NativeMethods.rcl_get_zero_initialized_publisher();
+            publisher = NativeMethods.rcl_get_zero_initialized_publisher();
             rcl_publisher_options_t publisherOptions = NativeMethods.rcl_publisher_get_default_options();
             IRclcsMessage msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
+            ret = (RCLReturnEnum)NativeMethods.rcl_publisher_init(ref publisher, ref node, typeSupportHandle, "publisher_test_topic", ref publisherOptions);
+            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+        }
 
-            // ret = (RCLReturnEnum)NativeMethods.rcl_publisher_init(ref publisher, ref node, typeSupportHandle, "publisher_test_topic", ref publisherOptions);
-
-            // shutdown
+        public static void ShutdownPublisher(ref rcl_publisher_t publisher, ref rcl_node_t node)
+        {
+            RCLReturnEnum ret;
             ret = (RCLReturnEnum)NativeMethods.rcl_publisher_fini(ref publisher, ref node);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+        }
+
+        [Test]
+        public void PublisherInit()
+        {
+            rcl_publisher_t publisher = new rcl_publisher_t();
+            InitPublisher(ref publisher, ref node);
+            ShutdownPublisher(ref publisher, ref node);
+
         } 
-        */
     }
 
     [TestFixture]
@@ -275,52 +294,34 @@ namespace rclcs.TestNativeMethods
     {
         rcl_context_t context;
         rcl_node_t node;
-        IntPtr defaultNodeOptions;
+        IntPtr nodeOptions = new IntPtr();
 
         [SetUp]
         public void SetUp()
         {
-            // init 
-            RCLReturnEnum ret;
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-            node = NativeMethods.rcl_get_zero_initialized_node();
-            string name = "publisher_test";
-            string nodeNamespace = "/ns";
-            defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-            NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, defaultNodeOptions);
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
         }
 
         [TearDown]
         public void TearDown()
         {
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
 
-        // FIXME(sam): Figure out why this fails and restore
-/* 
         [Test]
         public void PublisherPublish()
         {
             RCLReturnEnum ret;
-            rcl_publisher_t publisher = NativeMethods.rcl_get_zero_initialized_publisher();
-            rcl_publisher_options_t publisherOptions = NativeMethods.rcl_publisher_get_default_options();
-            std_msgs.msg.Bool msg = new std_msgs.msg.Bool();
-            IntPtr typeSupportHandle = msg.TypeSupportHandle;
-            ret = (RCLReturnEnum)NativeMethods.rcl_publisher_init(ref publisher, ref node, typeSupportHandle, "/publisher_test_topic", ref publisherOptions);
-            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+            rcl_publisher_t publisher = new rcl_publisher_t();
+            PublisherInitialize.InitPublisher(ref publisher, ref node);
+            IRclcsMessage msg = new std_msgs.msg.Bool();
             ret = (RCLReturnEnum)NativeMethods.rcl_publish(ref publisher, msg.Handle);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
-            ret = (RCLReturnEnum)NativeMethods.rcl_publisher_fini(ref publisher, ref node);
-            Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+            PublisherInitialize.ShutdownPublisher(ref publisher, ref node);
+
         }
- */
     }
 
     [TestFixture]
@@ -339,37 +340,43 @@ namespace rclcs.TestNativeMethods
             NativeMethods.rclcs_subscription_dispose_options(subscriptionOptions);
         }
 
-        [Test]
-        public void SubscriptionInit()
+        public static void InitSubscription(ref rcl_subscription_t subscription, IntPtr subscriptionOptions, ref rcl_node_t node)
         {
-            // init
             RCLReturnEnum ret;
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            rcl_context_t context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-            rcl_node_t node = NativeMethods.rcl_get_zero_initialized_node();
-            string name = "subscription_test";
-            string nodeNamespace = "/ns";
-            IntPtr defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-            NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, defaultNodeOptions);
-
-            rcl_subscription_t subscription = NativeMethods.rcl_get_zero_initialized_subscription();
-            IntPtr subscriptionOptions = NativeMethods.rclcs_subscription_create_default_options();
+            subscription = NativeMethods.rcl_get_zero_initialized_subscription();
+            subscriptionOptions = NativeMethods.rclcs_subscription_create_default_options();
             IRclcsMessage msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
             ret = (RCLReturnEnum)NativeMethods.rcl_subscription_init(ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
+        }
 
-            // shutdown
+        public static void ShutdownSubscription(ref rcl_subscription_t subscription, IntPtr subscriptionOptions, ref rcl_node_t node)
+        {
+            RCLReturnEnum ret;
             ret = (RCLReturnEnum)NativeMethods.rcl_subscription_fini(ref subscription, ref node);
             NativeMethods.rclcs_subscription_dispose_options(subscriptionOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+        }
+
+        [Test]
+        public void SubscriptionInit()
+        {
+            rcl_context_t context = new rcl_context_t();
+            rcl_node_t node = new rcl_node_t();
+            IntPtr nodeOptions = new IntPtr();
+
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+
+            rcl_subscription_t subscription = new rcl_subscription_t();
+            IntPtr subscriptionOptions = new IntPtr();
+
+            InitSubscription(ref subscription, subscriptionOptions, ref node);
+            ShutdownSubscription(ref subscription, subscriptionOptions, ref node);
+
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
     }
 
@@ -377,44 +384,24 @@ namespace rclcs.TestNativeMethods
     public class Subscription
     {
         rcl_context_t context;
-        rcl_allocator_t allocator;
         rcl_node_t node;
-        IntPtr defaultNodeOptions;
+        IntPtr nodeOptions = new IntPtr();
         rcl_subscription_t subscription;
-        IntPtr subscriptionOptions;
+        IntPtr subscriptionOptions = new IntPtr();
 
         [SetUp]
         public void SetUp()
         {
-            // init
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-            node = NativeMethods.rcl_get_zero_initialized_node();
-            string name = "subscription_test";
-            string nodeNamespace = "/ns";
-            defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-            NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, defaultNodeOptions);
-
-            subscription = NativeMethods.rcl_get_zero_initialized_subscription();
-            subscriptionOptions = NativeMethods.rclcs_subscription_create_default_options();
-            IRclcsMessage msg = new std_msgs.msg.Bool();
-            IntPtr typeSupportHandle = msg.TypeSupportHandle;
-            NativeMethods.rcl_subscription_init(ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
+            SubscriptionInitialize.InitSubscription(ref subscription, subscriptionOptions, ref node);
         }
 
         [TearDown]
         public void TearDown()
         {
-            // shutdown
-            NativeMethods.rcl_subscription_fini(ref subscription, ref node);
-            NativeMethods.rclcs_subscription_dispose_options(subscriptionOptions);
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
 
 
@@ -429,6 +416,7 @@ namespace rclcs.TestNativeMethods
         {
             NativeMethods.rcl_reset_error();
 
+            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator));
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_clear(ref waitSet));
@@ -445,26 +433,23 @@ namespace rclcs.TestNativeMethods
     public class WaitSet
     {
         rcl_context_t context;
-        rcl_allocator_t allocator;
+        rcl_node_t node;
+        IntPtr nodeOptions = new IntPtr();
 
         [SetUp]
         public void SetUp()
         {
-            // init
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
         }
 
         [TearDown]
         public void TearDown()
         {
-            // shutdown
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
+
         [Test]
         public void GetZeroInitializedWaitSet()
         {
@@ -477,6 +462,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void WaitSetInit()
         {
+            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator));
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_fini(ref waitSet));
@@ -485,6 +471,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void WaitSetClear()
         {
+            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
             NativeMethods.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator);
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_clear(ref waitSet));
@@ -498,32 +485,20 @@ namespace rclcs.TestNativeMethods
     {
         rcl_context_t context;
         rcl_node_t node;
-        IntPtr defaultNodeOptions;
+        IntPtr nodeOptions = new IntPtr();
 
         [SetUp]
         public void SetUp()
         {
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-
-            node = NativeMethods.rcl_get_zero_initialized_node();
-            defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-
-            string nodeName = "node_test";
-            string nodeNamespace = "/ns";
-            RCLReturnEnum ret = (RCLReturnEnum)NativeMethods.rcl_node_init(ref node, nodeName, nodeNamespace, ref context, defaultNodeOptions);
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
         }
 
         [TearDown]
         public void TearDown()
         {
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
 
         [Test]
@@ -551,39 +526,27 @@ namespace rclcs.TestNativeMethods
     public class Clock
     {
         rcl_context_t context;
-        rcl_allocator_t allocator;
         rcl_node_t node;
-        IntPtr defaultNodeOptions;
+        IntPtr nodeOptions = new IntPtr();
 
         [SetUp]
         public void SetUp()
         {
-            rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            allocator = NativeMethods.rcl_get_default_allocator();
-            NativeMethods.rcl_init_options_init(ref init_options, allocator);
-            context = NativeMethods.rcl_get_zero_initialized_context();
-            NativeMethods.rcl_init(0, null, ref init_options, ref context);
-
-            node = NativeMethods.rcl_get_zero_initialized_node();
-            defaultNodeOptions = NativeMethods.rclcs_node_create_default_options();
-
-            string nodeName = "node_test";
-            string nodeNamespace = "/ns";
-            RCLReturnEnum ret = (RCLReturnEnum)NativeMethods.rcl_node_init(ref node, nodeName, nodeNamespace, ref context, defaultNodeOptions);
+            RCLInitialize.InitRcl(ref context);
+            NodeInitialize.InitNode(ref node, nodeOptions, ref context);
         }
 
         [TearDown]
         public void TearDown()
         {
-            NativeMethods.rcl_node_fini(ref node);
-            NativeMethods.rclcs_node_dispose_options(defaultNodeOptions);
-            NativeMethods.rcl_shutdown(ref context);
-            NativeMethods.rcl_context_fini(ref context);
+            NodeInitialize.ShutdownNode(ref node, nodeOptions);
+            RCLInitialize.ShutdownRcl(ref context);
         }
 
         [Test]
         public void CreateClock()
         {
+            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
             IntPtr clockHandle = NativeMethods.rclcs_ros_clock_create(ref allocator);
             NativeMethods.rclcs_ros_clock_dispose(clockHandle);
         }
@@ -591,6 +554,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void ClockGetNow()
         {
+            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
             IntPtr clockHandle = NativeMethods.rclcs_ros_clock_create(ref allocator);
             long queryNow = 0;
             NativeMethods.rcl_clock_get_now(clockHandle, ref queryNow);


### PR DESCRIPTION
I refactored NativeTest and removed a lot of code-duplication to make them more maintainable. 

Also fixed an error in the initialization of the publisher. The publisher was working in spite of the error but probably causing an error message to be sent to `cout` using `stringstream` and crashing Unity.

Both the publisher and listener examples work with Connext in Unity now (https://github.com/DynoRobotics/unity_ros2/tree/dashing-minimal) :smile: 