### PR TITLE
Add utility scripts for creating standalone Unity projects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,20 +64,18 @@ workflows:
           filters:
             branches:
               only: 
-                - dashing
-                - automatic-testing
+                - master
       - test:
           requires:
             - build
           filters:
             branches:
               only: 
-                - dashing
-                - automatic-testing
+                - master
       - publish:
           requires:
             - test
           filters:
             branches:
               only: 
-                - dashing
+                - master

--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,5 @@ ModelManifest.xml
 # Debug files
 *.dSYM/
 *.su
+
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ROS2 for .NET
 =============
 
-[![CircleCI](https://circleci.com/gh/samiamlabs/ros2_dotnet/tree/dashing.svg?style=svg)](https://circleci.com/gh/samiamlabs/ros2_dotnet/tree/dashing)
+[![CircleCI](https://circleci.com/gh/samiamlabs/ros2_dotnet/tree/dashing.svg?style=svg)](https://circleci.com/gh/samiamlabs/ros2_dotnet/tree/master)
 
-ROS2 C# client library implementation. To my knowledge the most advanced ros2 C# project. 
+ROS2 C# client library implementation. To my knowledge the most advanced ros2 C# project.
 
 Notice
 ------
@@ -51,4 +51,3 @@ Contribution
 ------
 
 See Projects page for what tasks and contributions are needed.
-

--- a/rcldotnet/CMakeLists.txt
+++ b/rcldotnet/CMakeLists.txt
@@ -22,6 +22,8 @@ find_package(rmw_implementation_cmake REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
 
 find_package(dotnet_cmake_module REQUIRED)
+
+set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
 find_package(DotNETExtra REQUIRED)
 
 find_package(rcldotnet_common REQUIRED)

--- a/rcldotnet/INode.cs
+++ b/rcldotnet/INode.cs
@@ -7,7 +7,7 @@ namespace rclcs
     public interface INode: IDisposable
     {
         IList<ISubscriptionBase> Subscriptions { get; }
-        Publisher<T> CreatePublisher<T>(string topic) where T : IRclcsMessage, new();
+        Publisher<T> CreatePublisher<T>(string topic, QualityOfServiceProfile qos = null) where T : IRclcsMessage, new();
         Subscription<T> CreateSubscription<T>(string topic, Action<T> callback, QualityOfServiceProfile qos = null) where T : IRclcsMessage, new();
     }
 }

--- a/rcldotnet/NativeMethods.cs
+++ b/rcldotnet/NativeMethods.cs
@@ -333,7 +333,7 @@ namespace rclcs
         // --- RCUtils ---
         private static readonly IntPtr nativeRCUtils = dllLoadUtils.LoadLibraryNoSuffix("rcutils");
 
-        // rcl_get_default_allocator
+        // rcutils_get_default_allocator
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         internal delegate rcl_allocator_t RclGetDefaultAllocatorType();

--- a/rcldotnet_common/CMakeLists.txt
+++ b/rcldotnet_common/CMakeLists.txt
@@ -6,6 +6,8 @@ find_package(ament_cmake REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 find_package(ament_cmake_export_assemblies REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
+
+set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
 find_package(DotNETExtra REQUIRED)
 
 set(CS_SOURCES

--- a/rcldotnet_examples/CMakeLists.txt
+++ b/rcldotnet_examples/CMakeLists.txt
@@ -8,11 +8,12 @@ find_package(rcldotnet_common REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
+
 find_package(nav_msgs REQUIRED)
-find_package(rwmsgs REQUIRED)
-find_package(apm_msgs REQUIRED)
-find_package(apm_sensor_msgs REQUIRED)
-find_package(simulation_msgs REQUIRED)
+# find_package(rwmsgs REQUIRED)
+# find_package(apm_msgs REQUIRED)
+# find_package(apm_sensor_msgs REQUIRED)
+# find_package(simulation_msgs REQUIRED)
 find_package(dotnet_cmake_module REQUIRED)
 find_package(rosidl_generator_cs REQUIRED)
 
@@ -25,11 +26,11 @@ set(_assemblies_dep_dlls
     ${std_msgs_ASSEMBLIES_DLL}
     ${geometry_msgs_ASSEMBLIES_DLL}
     ${nav_msgs_ASSEMBLIES_DLL}
-    ${rwmsgs_ASSEMBLIES_DLL}
-    ${simulation_msgs_ASSEMBLIES_DLL}
-    ${apm_msgs_ASSEMBLIES_DLL}
-    ${apm_sensor_msgs_ASSEMBLIES_DLL}
-    ${rosidl_generator_ASSEMBLIES_DLL}
+    # ${rwmsgs_ASSEMBLIES_DLL}
+    # ${simulation_msgs_ASSEMBLIES_DLL}
+    # ${apm_msgs_ASSEMBLIES_DLL}
+    # ${apm_sensor_msgs_ASSEMBLIES_DLL}
+    # ${rosidl_generator_ASSEMBLIES_DLL}
 )
 
 message("Included assemblies for examples: ${_assemblies_dep_dlls}")

--- a/rcldotnet_examples/CMakeLists.txt
+++ b/rcldotnet_examples/CMakeLists.txt
@@ -33,7 +33,7 @@ set(_assemblies_dep_dlls
     # ${rosidl_generator_ASSEMBLIES_DLL}
 )
 
-message("Included assemblies for examples: ${_assemblies_dep_dlls}")
+# message("Included assemblies for examples: ${_assemblies_dep_dlls}")
 
 add_dotnet_executable(rcldotnet_talker
   RCLDotnetTalker.cs

--- a/rcldotnet_examples/package.xml
+++ b/rcldotnet_examples/package.xml
@@ -20,10 +20,12 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <!--
   <build_depend>rwmsgs</build_depend>
   <build_depend>simulation_msgs</build_depend>
   <build_depend>apm_sensor_msgs</build_depend>
   <build_depend>apm_msgs</build_depend>
+ -->
 
   <exec_depend>rcldotnet_common</exec_depend>
   <exec_depend>example_interfaces</exec_depend>
@@ -32,11 +34,13 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <!--
   <exec_depend>rwmsgs</exec_depend>
   <exec_depend>simulation_msgs</exec_depend>
   <exec_depend>apm_sensor_msgs</exec_depend>
   <exec_depend>apm_msgs</exec_depend>
-
+ -->
+ 
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rcldotnet_tests/CMakeLists.txt
+++ b/rcldotnet_tests/CMakeLists.txt
@@ -21,7 +21,7 @@ set(_assemblies_dep_dlls
     ${rosidl_generator_ASSEMBLIES_DLL}
 )
 
-message("Included assemblies for examples: ${_assemblies_dep_dlls}")
+# message("Included assemblies for examples: ${_assemblies_dep_dlls}")
 
 # TODO(sam): implement add_dotnet_tests (different name?), use this placeholder for now:
 add_dotnet_library(rcldotnet_tests

--- a/rcldotnet_tests/MessagesTest.cs
+++ b/rcldotnet_tests/MessagesTest.cs
@@ -38,9 +38,7 @@ namespace rclcs.Test
         public void SetStringData()
         {
             std_msgs.msg.String msg = new std_msgs.msg.String();
-            //NOTE(sam): msg.Data now initializes to null and not <string.Empty>, intentional?
-            // Assert.That(msg.Data, Is.EqualTo(""));
-            Assert.That(msg.Data, Is.EqualTo(null));
+            Assert.That(msg.Data, Is.EqualTo(""));
             msg.Data = "Show me what you got!";
             Assert.That(msg.Data, Is.EqualTo("Show me what you got!"));
         }

--- a/rcldotnet_tests/MessagesTest.cs
+++ b/rcldotnet_tests/MessagesTest.cs
@@ -62,127 +62,131 @@ namespace rclcs.Test
             msg.String_value = "Turtles all the way down";
             Assert.That(msg.String_value, Is.EqualTo("Turtles all the way down"));
         }
-/* 
         [Test]
-        public void SetDynamicArrayPrimitives()
+        public void SetUnboundedSequenses()
         {
-            test_msgs.msg.DynamicArrayPrimitives msg = new test_msgs.msg.DynamicArrayPrimitives();
-            List<bool> setBoolList = new List<bool>();
-            setBoolList.Add(true);
-            setBoolList.Add(false);
-            msg.bool_values = setBoolList;
-            List<bool> getBoolList = msg.bool_values;
-            Assert.That(getBoolList.Count, Is.EqualTo(2));
-            Assert.That(getBoolList[0], Is.True);
-            Assert.That(getBoolList[1], Is.False);
+            test_msgs.msg.UnboundedSequences msg = new test_msgs.msg.UnboundedSequences();
+            bool[] setBoolSequence = new bool[2];
+            setBoolSequence[0] = true;
+            setBoolSequence[1] = false;
+            msg.Bool_values = setBoolSequence;
 
-            List<int> setIntList = new List<int>();
-            setIntList.Add(123);
-            setIntList.Add(456);
-            test_msgs.msg.DynamicArrayPrimitives msg2 = new test_msgs.msg.DynamicArrayPrimitives();
-            msg2.int32_values = setIntList;
-            List<int> getIntList = msg2.int32_values;
-            Assert.That(getIntList.Count, Is.EqualTo(2));
+            bool[] getBoolSequence = msg.Bool_values;
+            Assert.That(getBoolSequence.Length, Is.EqualTo(2));
+            Assert.That(getBoolSequence[0], Is.True);
+            Assert.That(getBoolSequence[1], Is.False);
+
+            int[] setIntSequence = new int[2];
+            setIntSequence[0] = 123;
+            setIntSequence[1] = 456;
+            test_msgs.msg.UnboundedSequences msg2 = new test_msgs.msg.UnboundedSequences();
+            msg2.Int32_values = setIntSequence;
+            int[] getIntList = msg2.Int32_values;
+            Assert.That(getIntList.Length, Is.EqualTo(2));
             Assert.That(getIntList[0], Is.EqualTo(123));
+            Assert.That(getIntList[1], Is.EqualTo(456));
 
-            List<string> setStringList = new List<string>();
-            setStringList.Add("Hello");
-            setStringList.Add("world");
-            test_msgs.msg.DynamicArrayPrimitives msg3 = new test_msgs.msg.DynamicArrayPrimitives();
-            msg3.string_values = setStringList;
-            List<string> getStringList = msg3.string_values;
-            Assert.That(getStringList.Count, Is.EqualTo(2));
-            Assert.That(getStringList[0], Is.EqualTo("Hello"));
-            Assert.That(getStringList[1], Is.EqualTo("world"));
+            string[] setStringSequence = new string[2];
+            setStringSequence[0] = "Hello";
+            setStringSequence[1] = "world";
+            test_msgs.msg.UnboundedSequences msg3 = new test_msgs.msg.UnboundedSequences();
+            msg3.String_values = setStringSequence;
+            string[] getStringSequence = msg3.String_values;
+            Assert.That(getStringSequence.Length, Is.EqualTo(2));
+            Assert.That(getStringSequence[0], Is.EqualTo("Hello"));
+            Assert.That(getStringSequence[1], Is.EqualTo("world"));
         }
 
         [Test]
-        public void SetBoundedArrayPrimitives()
+        public void SetBoundedSequenses()
         {
-            test_msgs.msg.BoundedArrayPrimitives msg = new test_msgs.msg.BoundedArrayPrimitives();
-            List<bool> setBoolList = new List<bool>();
-            setBoolList.Add(true);
-            setBoolList.Add(false);
-            msg.bool_values = setBoolList;
-            List<bool> getBoolList = msg.bool_values;
-            Assert.That(getBoolList.Count, Is.EqualTo(2));
-            Assert.That(getBoolList[0], Is.True);
-            Assert.That(getBoolList[1], Is.False);
+            test_msgs.msg.BoundedSequences msg = new test_msgs.msg.BoundedSequences();
+            bool[] setBoolSequence = new bool[2];
+            setBoolSequence[0] = true;
+            setBoolSequence[1] = false;
+            msg.Bool_values = setBoolSequence;
 
-            List<int> setIntList = new List<int>();
-            setIntList.Add(123);
-            setIntList.Add(456);
-            test_msgs.msg.BoundedArrayPrimitives msg2 = new test_msgs.msg.BoundedArrayPrimitives();
-            msg2.int32_values = setIntList;
-            List<int> getIntList = msg2.int32_values;
-            Assert.That(getIntList.Count, Is.EqualTo(2));
+            bool[] getBoolSequence = msg.Bool_values;
+            Assert.That(getBoolSequence.Length, Is.EqualTo(2));
+            Assert.That(getBoolSequence[0], Is.True);
+            Assert.That(getBoolSequence[1], Is.False);
+
+            int[] setIntSequence = new int[2];
+            setIntSequence[0] = 123;
+            setIntSequence[1] = 456;
+            test_msgs.msg.BoundedSequences msg2 = new test_msgs.msg.BoundedSequences();
+            msg2.Int32_values = setIntSequence;
+            int[] getIntList = msg2.Int32_values;
+            Assert.That(getIntList.Length, Is.EqualTo(2));
             Assert.That(getIntList[0], Is.EqualTo(123));
+            Assert.That(getIntList[1], Is.EqualTo(456));
 
-            List<string> setStringList = new List<string>();
-            setStringList.Add("Hello");
-            setStringList.Add("world");
-            test_msgs.msg.BoundedArrayPrimitives msg3 = new test_msgs.msg.BoundedArrayPrimitives();
-            msg3.string_values = setStringList;
-            List<string> getStringList = msg3.string_values;
-            Assert.That(getStringList.Count, Is.EqualTo(2));
-            Assert.That(getStringList[0], Is.EqualTo("Hello"));
-            Assert.That(getStringList[1], Is.EqualTo("world"));
+            string[] setStringSequence = new string[2];
+            setStringSequence[0] = "Hello";
+            setStringSequence[1] = "world";
+            test_msgs.msg.BoundedSequences msg3 = new test_msgs.msg.BoundedSequences();
+            msg3.String_values = setStringSequence;
+            string[] getStringSequence = msg3.String_values;
+            Assert.That(getStringSequence.Length, Is.EqualTo(2));
+            Assert.That(getStringSequence[0], Is.EqualTo("Hello"));
+            Assert.That(getStringSequence[1], Is.EqualTo("world"));
         }
 
         [Test]
         public void SetNested()
         {
             test_msgs.msg.Nested msg = new test_msgs.msg.Nested();
-            test_msgs.msg.Primitives prim_msg = msg.primitive_values;
-            Assert.That(prim_msg.int32_value, Is.EqualTo(0));
-            prim_msg.int32_value = 25;
-            prim_msg.string_value = "wubalubadubdub";
-            Assert.That(prim_msg.int32_value, Is.EqualTo(25));
-            test_msgs.msg.Primitives prim_msg2 = msg.primitive_values;
-            Assert.That(prim_msg2.int32_value, Is.EqualTo(25));
-            Assert.That(prim_msg2.string_value, Is.EqualTo("wubalubadubdub"));
+            test_msgs.msg.BasicTypes basic_types_msg = msg.Basic_types_value;
+            Assert.That(basic_types_msg.Int32_value, Is.EqualTo(0));
+            basic_types_msg.Int32_value = 25;
+            Assert.That(basic_types_msg.Int32_value, Is.EqualTo(25));
+            test_msgs.msg.BasicTypes basic_types_msg2 = msg.Basic_types_value;
+            Assert.That(basic_types_msg2.Int32_value, Is.EqualTo(25));
         }
 
         [Test]
-        public void SetDynamicArrayNested()
+        public void SetMultiNested()
         {
-            test_msgs.msg.DynamicArrayNested msg = new test_msgs.msg.DynamicArrayNested();
+            test_msgs.msg.MultiNested msg = new test_msgs.msg.MultiNested();
 
-            msg.primitive_values_init(3);
-            Assert.That(msg.primitive_values.Count, Is.EqualTo(3));
+            msg.Unbounded_sequence_of_unbounded_sequences = new test_msgs.msg.UnboundedSequences[3];
+            var setUnboundedSequences = new test_msgs.msg.UnboundedSequences();
+            string[] string_array = new string[2];
+            setUnboundedSequences.String_values = string_array;
+            setUnboundedSequences.String_values[0] = "hello";
 
-            var listOfNestedMsgs = msg.primitive_values;
+            msg.Unbounded_sequence_of_unbounded_sequences[0] = setUnboundedSequences;
+            msg.Unbounded_sequence_of_unbounded_sequences[0].String_values[1] = "world";
 
-            listOfNestedMsgs[0].string_value = "hello";
-            Assert.That(listOfNestedMsgs[0].string_value, Is.EqualTo("hello"));
+            Assert.That(msg.Unbounded_sequence_of_unbounded_sequences.Length, Is.EqualTo(3));
 
-            listOfNestedMsgs[1].string_value = "world";
-            Assert.That(listOfNestedMsgs[1].string_value, Is.EqualTo("world"));
+            var getUnboundedOfUnbounded = msg.Unbounded_sequence_of_unbounded_sequences;
 
-            var readListOfNestedMsgs = msg.primitive_values;
-            Assert.That(readListOfNestedMsgs[0].string_value, Is.EqualTo("hello"));
-            Assert.That(readListOfNestedMsgs[1].string_value, Is.EqualTo("world"));
+            Assert.That(getUnboundedOfUnbounded[0].String_values[0], Is.EqualTo("hello"));
+            Assert.That(getUnboundedOfUnbounded[0].String_values[1], Is.EqualTo("world"));
         }
 
-        // NOTE(samiam): memory issues, does not work yet...
+        /*
+
+        // NOTE(samiam): does not work yet
         [Test]
         public void SetStaticArrayPrimitives()
         {
             test_msgs.msg.StaticArrayPrimitives msg = new test_msgs.msg.StaticArrayPrimitives();
-            List<bool> setBoolList = new List<bool>();
-            setBoolList.Add(true);
-            setBoolList.Add(false);
-            msg.bool_values = setBoolList;
-            List<bool> getBoolList = msg.bool_values;
-            Assert.That(getBoolList.Count, Is.EqualTo(3));
-            Assert.That(getBoolList[0], Is.True);
-            Assert.That(getBoolList[1], Is.False);
+            List<bool> setBoolSequence = new List<bool>();
+            setBoolSequence.Add(true);
+            setBoolSequence.Add(false);
+            msg.bool_values = setBoolSequence;
+            List<bool> getBoolSequence = msg.bool_values;
+            Assert.That(getBoolSequence.Count, Is.EqualTo(3));
+            Assert.That(getBoolSequence[0], Is.True);
+            Assert.That(getBoolSequence[1], Is.False);
 
-            //List<int> setIntList = new List<int>();
-            //setIntList.Add(123);
-            //setIntList.Add(456);
+            //List<int> setIntSequence = new List<int>();
+            //setIntSequence.Add(123);
+            //setIntSequence.Add(456);
             //test_msgs.msg.StaticArrayPrimitives msg2 = new test_msgs.msg.StaticArrayPrimitives();
-            //msg2.int32_values = setIntList;
+            //msg2.int32_values = setIntSequence;
             //List<int> getIntList = msg2.int32_values;
             //Assert.That(getIntList.Count, Is.EqualTo(3));
             //Assert.That(getIntList[0], Is.EqualTo(123));

--- a/rcldotnet_tests/NativeMetodsTest.cs
+++ b/rcldotnet_tests/NativeMetodsTest.cs
@@ -19,7 +19,7 @@ namespace rclcs.TestNativeMethods
             RCLReturnEnum ret;
             NativeMethods.rcl_reset_error();
             rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             ret = (RCLReturnEnum)NativeMethods.rcl_init_options_init(ref init_options, allocator);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
 
@@ -77,7 +77,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void GetDefaultAllocator()
         {
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace rclcs.TestNativeMethods
         public void InitOptionsInit()
         {
             rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             int ret = NativeMethods.rcl_init_options_init(ref init_options, allocator);
             Assert.That((RCLReturnEnum)ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
         }
@@ -114,7 +114,7 @@ namespace rclcs.TestNativeMethods
         public void InitValidArgs()
         {
             rcl_init_options_t init_options = NativeMethods.rcl_get_zero_initialized_init_options();
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             NativeMethods.rcl_init_options_init(ref init_options, allocator);
             rcl_context_t context = NativeMethods.rcl_get_zero_initialized_context();
 
@@ -418,7 +418,7 @@ namespace rclcs.TestNativeMethods
         {
             NativeMethods.rcl_reset_error();
 
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator));
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_clear(ref waitSet));
@@ -464,7 +464,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void WaitSetInit()
         {
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator));
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_fini(ref waitSet));
@@ -473,7 +473,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void WaitSetClear()
         {
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
             NativeMethods.rcl_wait_set_init(ref waitSet, 1, 0, 0, 0, 0, 0, ref context, allocator);
             TestUtils.AssertRetOk(NativeMethods.rcl_wait_set_clear(ref waitSet));
@@ -548,7 +548,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void CreateClock()
         {
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             IntPtr clockHandle = NativeMethods.rclcs_ros_clock_create(ref allocator);
             NativeMethods.rclcs_ros_clock_dispose(clockHandle);
         }
@@ -556,7 +556,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void ClockGetNow()
         {
-            rcl_allocator_t allocator = NativeMethods.rcl_get_default_allocator();
+            rcl_allocator_t allocator = NativeMethods.rcutils_get_default_allocator();
             IntPtr clockHandle = NativeMethods.rclcs_ros_clock_create(ref allocator);
             long queryNow = 0;
             NativeMethods.rcl_clock_get_now(clockHandle, ref queryNow);

--- a/rcldotnet_tests/NativeMetodsTest.cs
+++ b/rcldotnet_tests/NativeMetodsTest.cs
@@ -29,7 +29,7 @@ namespace rclcs.TestNativeMethods
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
 
             Assert.That(NativeMethods.rcl_context_is_valid(ref context), Is.True);
-            
+
         }
 
         public static void ShutdownRcl(ref rcl_context_t context)
@@ -172,7 +172,7 @@ namespace rclcs.TestNativeMethods
             RCLReturnEnum ret = (RCLReturnEnum)NativeMethods.rcl_node_init(ref node, name, nodeNamespace, ref context, nodeOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK));
         }
-        
+
         public static void ShutdownNode(ref rcl_node_t node, IntPtr nodeOptions)
         {
             NativeMethods.rcl_node_fini(ref node);
@@ -266,7 +266,7 @@ namespace rclcs.TestNativeMethods
             RCLReturnEnum ret;
             publisher = NativeMethods.rcl_get_zero_initialized_publisher();
             publisherOptions = NativeMethods.rclcs_publisher_create_default_options();
-            IRclcsMessage msg = new std_msgs.msg.Bool();
+            IMessageInternals msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
             ret = (RCLReturnEnum)NativeMethods.rcl_publisher_init(ref publisher, ref node, typeSupportHandle, "publisher_test_topic", publisherOptions);
         }
@@ -287,7 +287,7 @@ namespace rclcs.TestNativeMethods
             InitPublisher(ref publisher, ref node, publisherOptions);
             ShutdownPublisher(ref publisher, ref node, publisherOptions);
 
-        } 
+        }
     }
 
     [TestFixture]
@@ -318,7 +318,7 @@ namespace rclcs.TestNativeMethods
             rcl_publisher_t publisher = new rcl_publisher_t();
             IntPtr publisherOptions = new IntPtr();
             PublisherInitialize.InitPublisher(ref publisher, ref node, publisherOptions);
-            IRclcsMessage msg = new std_msgs.msg.Bool();
+            IMessageInternals msg = new std_msgs.msg.Bool();
             ret = (RCLReturnEnum)NativeMethods.rcl_publish(ref publisher, msg.Handle);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
             PublisherInitialize.ShutdownPublisher(ref publisher, ref node, publisherOptions);
@@ -347,7 +347,7 @@ namespace rclcs.TestNativeMethods
             RCLReturnEnum ret;
             subscription = NativeMethods.rcl_get_zero_initialized_subscription();
             subscriptionOptions = NativeMethods.rclcs_subscription_create_default_options();
-            IRclcsMessage msg = new std_msgs.msg.Bool();
+            IMessageInternals msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
             ret = (RCLReturnEnum)NativeMethods.rcl_subscription_init(ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
             Assert.That(ret, Is.EqualTo(RCLReturnEnum.RCL_RET_OK), Utils.PopRclErrorString());
@@ -455,7 +455,7 @@ namespace rclcs.TestNativeMethods
         [Test]
         public void GetZeroInitializedWaitSet()
         {
-            // NOTE: The struct rcl_wait_set_t contains size_t 
+            // NOTE: The struct rcl_wait_set_t contains size_t
             // fields that are set to UIntPtr in C# declaration,
             // not guaranteed to work for all C implemenations/platforms.
             rcl_wait_set_t waitSet = NativeMethods.rcl_get_zero_initialized_wait_set();
@@ -511,7 +511,7 @@ namespace rclcs.TestNativeMethods
 
             NativeMethods.rclcs_subscription_set_qos_profile(subscriptionOptions, 0);
 
-            IRclcsMessage msg = new std_msgs.msg.Bool();
+            IMessageInternals msg = new std_msgs.msg.Bool();
             IntPtr typeSupportHandle = msg.TypeSupportHandle;
             NativeMethods.rcl_subscription_init(ref subscription, ref node, typeSupportHandle, "/subscriber_test_topic", subscriptionOptions);
 

--- a/rcldotnet_tests/SubscriptionTest.cs
+++ b/rcldotnet_tests/SubscriptionTest.cs
@@ -40,7 +40,7 @@ namespace rclcs.Test
         [Test]
         public void SubscriptionCallbackMessageData()
         {
-            int messageData = 0;
+            int messageData = 12345;
             node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic", (msg) => { messageData = msg.Data; });
             std_msgs.msg.Int32 published_msg = new std_msgs.msg.Int32();
             published_msg.Data = 42;
@@ -54,9 +54,9 @@ namespace rclcs.Test
         public void SubscriptionQosDefaultDepth()
         {
             int count = 0;
-            node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic", 
+            node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic",
                                                         (msg) => { count += 1; });
-        
+
             std_msgs.msg.Int32 published_msg = new std_msgs.msg.Int32();
             published_msg.Data = 42;
 
@@ -74,17 +74,17 @@ namespace rclcs.Test
         }
 
         // FIXME(sam): this occasionally returns 6 and to 5... very strange...
-/* 
+/*
         [Test]
         public void SubscriptionQosSensorDataDepth()
         {
             int count = 0;
             QualityOfServiceProfile qosProfile = new QualityOfServiceProfile(QosProfiles.SENSOR_DATA);
 
-            node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic", 
+            node.CreateSubscription<std_msgs.msg.Int32>("subscription_test_topic",
                                                         (msg) => { count += 1; },
                                                         qosProfile);
-        
+
             std_msgs.msg.Int32 published_msg = new std_msgs.msg.Int32();
             published_msg.Data = 42;
 

--- a/rcldotnet_tests/rcldotnet_tests.csproj
+++ b/rcldotnet_tests/rcldotnet_tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/rcldotnet_tests/rcldotnet_tests.csproj
+++ b/rcldotnet_tests/rcldotnet_tests.csproj
@@ -15,13 +15,13 @@
   <ItemGroup>
     <ProjectReference Include="..\rcldotnet\rcldotnet.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Reference Include="std_msgs">
-      <HintPath>../../../../install/rcldotnet_tests/lib/rcldotnet_tests/dotnet/std_msgs_assembly.dll</HintPath>
+      <HintPath>../../../../install/Lib/dotnet/std_msgs_assembly.dll</HintPath>
     </Reference>
     <Reference Include="test_msgs">
-      <HintPath>../../../../install/rcldotnet_tests/lib/rcldotnet_tests/dotnet/test_msgs_assembly.dll</HintPath>
+      <HintPath>../../../../install/Lib/dotnet/test_msgs_assembly.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/rcldotnet_tests/rcldotnet_tests.csproj
+++ b/rcldotnet_tests/rcldotnet_tests.csproj
@@ -18,10 +18,10 @@
 
   <ItemGroup>
     <Reference Include="std_msgs">
-      <HintPath>../../../../install/Lib/dotnet/std_msgs_assembly.dll</HintPath>
+      <HintPath>../../../../install/rcldotnet_tests/lib/rcldotnet_tests/dotnet/std_msgs_assembly.dll</HintPath>
     </Reference>
     <Reference Include="test_msgs">
-      <HintPath>../../../../install/Lib/dotnet/test_msgs_assembly.dll</HintPath>
+      <HintPath>../../../../install/rcldotnet_tests/lib/rcldotnet_tests/dotnet/test_msgs_assembly.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/rcldotnet_utils/package.xml
+++ b/rcldotnet_utils/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rcldotnet_utils</name>
+  <version>0.0.0</version>
+  <description>
+   Utility scripts for rcldotnet
+  </description>
+  <maintainer email="samuel@dynorobotics.se">Samuel Lindgren</maintainer>
+  <license>Apache License 2.0</license>
+  <exec_depend>rclpy</exec_depend>
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
+++ b/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
@@ -73,17 +73,18 @@ class UnityROS2LibCopier:
 
                 if platform.system() == 'Windows':
                     filename_extensions = ('.dll')
-                    lib_folder = '/bin'
+                    lib_folder = '\\bin'
                     package_lib_path = package_install_path + lib_folder
                 else:
                     filename_extensions = ('.so', '.so.1', 'so.2')
                     lib_folder = '/lib'
                     package_lib_path = package_install_path + lib_folder
 
-                for c_lib_file in os.listdir(package_lib_path):
-                    if c_lib_file.endswith(filename_extensions):
-                        self.c_lib_source_dict[c_lib_file] = (
-                            package_lib_path + '/' + c_lib_file)
+                if os.path.isdir(package_lib_path):
+                    for c_lib_file in os.listdir(package_lib_path):
+                        if c_lib_file.endswith(filename_extensions):
+                            self.c_lib_source_dict[c_lib_file] = (
+                                package_lib_path + '/' + c_lib_file)
 
                 # Find ament compiled projects not found by ament_index
                 # by looking in parent folders of ros install directories

--- a/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
+++ b/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
@@ -32,7 +32,9 @@ class UnityROS2LibCopier:
             'sensor_msgs',
             'tf2_msgs',
             'nav_msgs',
-            'test_msgs'
+            'test_msgs',
+            'action_msgs',
+            'unique_identifier_msgs',
         ]
 
         self.dependencies = [

--- a/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
+++ b/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
@@ -164,14 +164,36 @@ def directory_is_a_unity_project(dir_path):
 def copy_unity_files(unity_project_path):
     unity_files_path = pkg_resources.resource_filename('rcldotnet_utils',
                                                        'unity_files')
+
     asset_path = unity_project_path + '/Assets'
+
+    unity_resource_path = asset_path + '/Resources'
+    if not os.path.isdir(unity_resource_path):
+        try:
+            os.makedirs(unity_resource_path)
+        except OSError:
+            logging.error('Failed to create directory {}'.format(
+                unity_resource_path))
+        else:
+            logging.info('Successfully created the directory {}'.format(
+                unity_resource_path))
+
+    unity_editor_scripts_path = asset_path + '/Editor/ROS'
+    if not os.path.isdir(unity_editor_scripts_path):
+        try:
+            os.makedirs(unity_editor_scripts_path)
+        except OSError:
+            logging.error('Failed to create directory {}'.format(
+                unity_editor_scripts_path))
+        else:
+            logging.info('Successfully created the directory {}'.format(
+                unity_editor_scripts_path))
 
     source_path = unity_files_path + '/start_editor.py'
     destination_path = asset_path + '/start_editor.py'
-
     if should_copy_file(source_path, destination_path):
         logging.info('Copying start_editor.py')
-        shutil.copy2(source_path, asset_path)
+        shutil.copy2(source_path, destination_path)
 
     if platform.system() == 'Windows':
         source_path = unity_files_path + '/start_editor.bat'
@@ -181,12 +203,39 @@ def copy_unity_files(unity_project_path):
         destination_path = asset_path + '/start_editor.bash'
     if should_copy_file(source_path, destination_path):
         logging.info('Copying start_editor script')
-        shutil.copy2(source_path, asset_path)
+        shutil.copy2(source_path, destination_path)
 
     if platform.system() == 'Linux':
-        logging.info('Making script executable')
+        logging.info('Making editor script executable')
         st = os.stat(destination_path)
         os.chmod(destination_path, st.st_mode | stat.S_IEXEC)
+
+    source_path = unity_files_path + '/start_player.py'
+    destination_path = unity_resource_path + '/start_player.py'
+    if should_copy_file(source_path, destination_path):
+        logging.info('Copying start_player.py')
+        shutil.copy2(source_path, destination_path)
+
+    if platform.system() == 'Windows':
+        source_path = unity_files_path + '/start_player.bat'
+        destination_path = unity_resource_path + '/start_player.bat'
+    else:
+        source_path = unity_files_path + '/start_player.bash'
+        destination_path = unity_resource_path + '/start_player.bash'
+    if should_copy_file(source_path, destination_path):
+        logging.info('Copying start_player script')
+        shutil.copy2(source_path, destination_path)
+
+    if platform.system() == 'Linux':
+        logging.info('Making player script executable')
+        st = os.stat(destination_path)
+        os.chmod(destination_path, st.st_mode | stat.S_IEXEC)
+
+    source_path = unity_files_path + '/BuildRos.cs'
+    destination_path = unity_editor_scripts_path + '/BuildRos.cs'
+    if should_copy_file(source_path, destination_path):
+        logging.info('Copying BuildRos.cs')
+        shutil.copy2(source_path, destination_path)
 
 
 def main():

--- a/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
+++ b/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
@@ -1,0 +1,135 @@
+import sys
+import os
+import argparse
+import logging
+import shutil
+
+from ament_index_python import get_package_prefix
+from ament_index_python.packages import PackageNotFoundError
+
+class UnityROS2LibCopier:
+    def __init__(self, unity_project_path):
+        self.ament_dependencies = [
+            # 'rcl',
+            # 'rcl_interfaces',
+            # 'rmw',
+            # 'rmw_implementation',
+            # 'rmw_fastrtps_shared_cpp',
+            # 'rosidl_generator_c',
+            # 'rcl_logging_noop',
+            # 'rmw_fastrtps_cpp',
+            # 'rcutils',
+            'rcldotnet',
+            # 'fastrtps',
+            'std_msgs',
+            'geometry_msgs',
+            'sensor_msgs',
+            # 'tf2_msgs',
+            'nav_msgs',
+            'test_msgs'
+        ]
+
+        self.c_lib_source_dict = {}
+        self.c_lib_destination_dir = unity_project_path + '/Assets/Plugins/x86_64'
+        # self.c_lib_destination_dir = unity_project_path + '/Assets/Plugins'
+
+        self.cs_lib_source_dict = {}
+        self.cs_lib_destination_dir = unity_project_path + '/Assets/Plugins'
+
+        self.__find_libs()
+
+        
+    def copy_files(self):
+        self.__copy_files_from_dict(self.c_lib_source_dict, 
+                                    self.c_lib_destination_dir)
+
+        self.__copy_files_from_dict(self.cs_lib_source_dict,
+                                    self.cs_lib_destination_dir)
+
+    def __find_libs(self):
+        self.__find_c_libs()
+        self.__find_csharp_libs()
+
+    def __find_c_libs(self):
+        for package_name in self.ament_dependencies:
+            try:
+                package_install_path = get_package_prefix(package_name)
+                package_lib_path = package_install_path + '/lib'
+                for c_lib_file in os.listdir(package_lib_path):
+                    if c_lib_file.endswith('.so'):
+                        self.c_lib_source_dict[c_lib_file] = (
+                            package_lib_path + '/' + c_lib_file)
+            except PackageNotFoundError:
+                print('{} not found!'.format(package_name))
+
+    def __find_csharp_libs(self):
+        for package_name in self.ament_dependencies:
+            try:
+                package_install_path = get_package_prefix(package_name)
+                package_lib_path = package_install_path + '/lib/dotnet'
+                if os.path.isdir(package_lib_path):
+                    for csharp_lib_file in os.listdir(package_lib_path):
+                        if csharp_lib_file.endswith('.dll'):
+                            self.cs_lib_source_dict[csharp_lib_file] = (
+                                package_lib_path + '/' + csharp_lib_file)
+            except PackageNotFoundError:
+                print('{} not found!'.format(package_name))
+
+    def __copy_files_from_dict(self, source_dictionary, destination_directory):
+        if not os.path.isdir(destination_directory):
+            try:
+               os.makedirs(destination_directory) 
+            except OSError:
+                logging.error('Failed to create directory {}'.format(destination_directory))
+            else:
+                logging.info('Successfully created the directory {}'.format(destination_directory))
+            
+        for filename, source_path in source_dictionary.items():
+            destination_path = destination_directory + '/' + filename
+            if self.__should_copy_file(source_path, destination_path):
+                logging.info('Copying "{}"'.format(filename))
+                shutil.copy2(source_path, destination_path)
+
+    def __should_copy_file(self, source_path, destination_path):
+
+        def does_not_exist(destination_path):
+            return not os.path.isfile(destination_path)
+
+        def newer_verson_available(source_path, destination_path):
+            return (os.stat(source_path).st_mtime
+                    - os.stat(destination_path).st_mtime > 0)
+
+        return (does_not_exist(destination_path)
+                or newer_verson_available(source_path, destination_path))
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--unity-project', default=os.getcwd(), help='Path to Unity project'
+    )
+
+    return parser.parse_args(args)
+
+def directory_is_a_unity_project(dir_path):
+    unity_project_settings = dir_path + '/ProjectSettings/ProjectSettings.asset'
+    return os.path.isfile(unity_project_settings)
+
+def main():
+    logging.basicConfig(level=logging.DEBUG)
+
+    parsed = parse_args(sys.argv[1:])
+    # parsed = parse_args(['--unity-project', 
+    #                      '/home/sam/dyno/dotnet/unity_ws/src/unity/unity_ros2'])
+
+    if directory_is_a_unity_project(parsed.unity_project):
+        global lib_copier
+        lib_copier = UnityROS2LibCopier(parsed.unity_project)
+        lib_copier.copy_files()
+    else:
+        logging.error('The selected folder "{}" does not appear to be a Unity3D project.'.format(
+            parsed.unity_project
+        ))
+
+if __name__ == '__main__':
+    main()

--- a/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
+++ b/rcldotnet_utils/rcldotnet_utils/init_unity_project.py
@@ -3,44 +3,54 @@ import os
 import argparse
 import logging
 import shutil
+import platform
+import pkg_resources
 
 from ament_index_python import get_package_prefix
 from ament_index_python.packages import PackageNotFoundError
 
+
 class UnityROS2LibCopier:
     def __init__(self, unity_project_path):
         self.ament_dependencies = [
-            # 'rcl',
-            # 'rcl_interfaces',
-            # 'rmw',
-            # 'rmw_implementation',
-            # 'rmw_fastrtps_shared_cpp',
-            # 'rosidl_generator_c',
-            # 'rcl_logging_noop',
-            # 'rmw_fastrtps_cpp',
-            # 'rcutils',
+            'rcl',
+            'rcl_interfaces',
+            'rmw',
+            'rmw_implementation',
+            'rmw_fastrtps_cpp',
+            'rmw_fastrtps_dynamic_cpp',
+            'rmw_fastrtps_shared_cpp',
+            'rosidl_generator_c',
+            'rosidl_typesupport_c',
+            'rosidl_typesupport_fastrtps_c',
+            'rosidl_typesupport_fastrtps_cpp',
+            'builtin_interfaces',
+            'rcutils',
             'rcldotnet',
-            # 'fastrtps',
             'std_msgs',
             'geometry_msgs',
             'sensor_msgs',
-            # 'tf2_msgs',
+            'tf2_msgs',
             'nav_msgs',
             'test_msgs'
         ]
 
+        self.dependencies = [
+            'poco_vendor',
+            'fastcdr',
+            'fastrtps',
+        ]
+
         self.c_lib_source_dict = {}
         self.c_lib_destination_dir = unity_project_path + '/Assets/Plugins/x86_64'
-        # self.c_lib_destination_dir = unity_project_path + '/Assets/Plugins'
 
         self.cs_lib_source_dict = {}
         self.cs_lib_destination_dir = unity_project_path + '/Assets/Plugins'
 
         self.__find_libs()
 
-        
     def copy_files(self):
-        self.__copy_files_from_dict(self.c_lib_source_dict, 
+        self.__copy_files_from_dict(self.c_lib_source_dict,
                                     self.c_lib_destination_dir)
 
         self.__copy_files_from_dict(self.cs_lib_source_dict,
@@ -54,11 +64,36 @@ class UnityROS2LibCopier:
         for package_name in self.ament_dependencies:
             try:
                 package_install_path = get_package_prefix(package_name)
-                package_lib_path = package_install_path + '/lib'
+                package_install_parent_directory = os.path.abspath(
+                    os.path.join(package_install_path, os.pardir))
+
+                if platform.system() == 'Windows':
+                    filename_extension = '.dll'
+                    lib_folder = '/bin'
+                    package_lib_path = package_install_path + lib_folder
+                else:
+                    filename_extension = '.so'
+                    lib_folder = '/lib'
+                    package_lib_path = package_install_path + lib_folder
+
                 for c_lib_file in os.listdir(package_lib_path):
-                    if c_lib_file.endswith('.so'):
+                    if c_lib_file.endswith(filename_extension):
                         self.c_lib_source_dict[c_lib_file] = (
                             package_lib_path + '/' + c_lib_file)
+
+                # Find ament compiled projects not found by ament_index
+                # by looking in parent folders of ros install directories
+                for non_ros_package in self.dependencies:
+                    if non_ros_package in os.listdir(package_install_parent_directory):
+                        lib_path = package_install_parent_directory + '/' + non_ros_package + lib_folder
+                        try:
+                            for c_lib_file in os.listdir(lib_path):
+                                if c_lib_file.endswith(filename_extension):
+                                    self.c_lib_source_dict[c_lib_file] = (
+                                        lib_path + '/' + c_lib_file)
+                        except PackageNotFoundError:
+                            pass
+
             except PackageNotFoundError:
                 print('{} not found!'.format(package_name))
 
@@ -78,58 +113,84 @@ class UnityROS2LibCopier:
     def __copy_files_from_dict(self, source_dictionary, destination_directory):
         if not os.path.isdir(destination_directory):
             try:
-               os.makedirs(destination_directory) 
+                os.makedirs(destination_directory)
             except OSError:
-                logging.error('Failed to create directory {}'.format(destination_directory))
+                logging.error('Failed to create directory {}'.format(
+                    destination_directory))
             else:
-                logging.info('Successfully created the directory {}'.format(destination_directory))
-            
+                logging.info('Successfully created the directory {}'.format(
+                    destination_directory))
+
         for filename, source_path in source_dictionary.items():
             destination_path = destination_directory + '/' + filename
-            if self.__should_copy_file(source_path, destination_path):
+            if should_copy_file(source_path, destination_path):
                 logging.info('Copying "{}"'.format(filename))
                 shutil.copy2(source_path, destination_path)
 
-    def __should_copy_file(self, source_path, destination_path):
 
-        def does_not_exist(destination_path):
-            return not os.path.isfile(destination_path)
+def should_copy_file(source_path, destination_path):
 
-        def newer_verson_available(source_path, destination_path):
-            return (os.stat(source_path).st_mtime
-                    - os.stat(destination_path).st_mtime > 0)
+    def does_not_exist(destination_path):
+        return not os.path.isfile(destination_path)
 
-        return (does_not_exist(destination_path)
-                or newer_verson_available(source_path, destination_path))
+    def newer_verson_available(source_path, destination_path):
+        return (os.stat(source_path).st_mtime
+                - os.stat(destination_path).st_mtime > 0)
+
+    return (does_not_exist(destination_path)
+            or newer_verson_available(source_path, destination_path))
+
 
 def parse_args(args):
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        '--unity-project', default=os.getcwd(), help='Path to Unity project'
+        '--unity-project', default=os.getcwd(), help='path to Unity project'
     )
 
     return parser.parse_args(args)
+
 
 def directory_is_a_unity_project(dir_path):
     unity_project_settings = dir_path + '/ProjectSettings/ProjectSettings.asset'
     return os.path.isfile(unity_project_settings)
 
+
+def copy_unity_files(unity_project_path):
+    unity_files_path = pkg_resources.resource_filename('rcldotnet_utils',
+                                                       'unity_files')
+    asset_path = unity_project_path + '/Assets'
+
+    source_path = unity_files_path + '/start_editor.py'
+    destination_path = asset_path + '/start_editor.py'
+
+    if should_copy_file(source_path, destination_path):
+        logging.info('Copying start_editor.py')
+        shutil.copy2(source_path, asset_path)
+
+    if platform.system() == 'Windows':
+        source_path = unity_files_path + '/start_editor.bat'
+        destination_path = asset_path + '/start_editor.bat'
+        if should_copy_file(source_path, destination_path):
+            logging.info('Copying start_editor.bat')
+            shutil.copy2(source_path, asset_path)
+
+
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
     parsed = parse_args(sys.argv[1:])
-    # parsed = parse_args(['--unity-project', 
-    #                      '/home/sam/dyno/dotnet/unity_ws/src/unity/unity_ros2'])
 
     if directory_is_a_unity_project(parsed.unity_project):
-        global lib_copier
         lib_copier = UnityROS2LibCopier(parsed.unity_project)
         lib_copier.copy_files()
+
+        copy_unity_files(parsed.unity_project)
     else:
-        logging.error('The selected folder "{}" does not appear to be a Unity3D project.'.format(
+        logging.error('The selected folder "{}" does not appear to be the root of a Unity3D project.'.format(
             parsed.unity_project
         ))
+
 
 if __name__ == '__main__':
     main()

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/BuildRos.cs
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/BuildRos.cs
@@ -1,0 +1,40 @@
+// C# example.
+using UnityEditor;
+using System.Diagnostics;
+
+public class ScriptBatch
+{
+    [MenuItem("ROS/Windows Build")]
+    public static void BuildGameWindows()
+    {
+        // Get filename.
+        string path = EditorUtility.SaveFolderPanel("Choose Location of Built Game", "", "");
+        string[] levels = new string[] { "Assets/Scenes/RosExample.unity"};
+
+        // Build player.
+        BuildPipeline.BuildPlayer(levels, path + "/BuiltGame.exe", BuildTarget.StandaloneWindows64, BuildOptions.None);
+
+        // Copy a file from the project folder to the build folder, alongside the built game.
+        FileUtil.CopyFileOrDirectory("Assets/Resources/start_player.py", path + "/start_player.py");
+        FileUtil.CopyFileOrDirectory("Assets/Resources/start_player.bat", path + "/start_player.bat");
+
+    }
+
+    [MenuItem("ROS/Linux Build")]
+    public static void BuildGameLinux()
+    {
+        // Get filename.
+        // FIXME(sam): creates folder for some reason... Allow setting name of game?
+        string path = EditorUtility.SaveFolderPanel("Choose Location of Built Game", "", "");
+        // string path = System.IO.Path.GetDirectoryName(file_path);
+        string[] levels = new string[] { "Assets/Scenes/RosExample.unity"};
+
+        // Build player.
+        BuildPipeline.BuildPlayer(levels, path + "/BuiltGame", BuildTarget.StandaloneLinux64, BuildOptions.None);
+
+        // Copy a file from the project folder to the build folder, alongside the built game.
+        FileUtil.CopyFileOrDirectory("Assets/Resources/start_player.py", path + "/start_player.py");
+        FileUtil.CopyFileOrDirectory("Assets/Resources/start_player.bash", path + "/start_player.bash");
+
+    }
+}

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.bash
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 start_editor.py

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.bat
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.bat
@@ -1,0 +1,1 @@
+python start_editor.py

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.py
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import subprocess
+import yaml
+import argparse
+
+from tkinter.filedialog import askopenfilename
+
+import argparse
+
+parser = argparse.ArgumentParser(description='Start Unity Editor with ROS2 support')
+parser.add_argument('--select-editor', action='store_true', help='select executable for the editor')
+args = parser.parse_args()
+
+config_filename = 'ros_config.yaml'
+
+# Defaults
+yaml_data = {
+    'unity_editor_filename': None,
+    'c_libs_asset_path': 'Plugins\\x86_64'
+}
+
+if os.path.isfile(config_filename):
+    with open(config_filename) as stream:
+        try:
+            yaml_data = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+else:
+    print('Config file does not exsist, creating!')
+    with open(config_filename, 'w') as outfile:
+        yaml.dump(yaml_data, outfile, default_flow_style=False)
+
+if yaml_data['unity_editor_filename'] == None or args.select_editor:
+    filename =  askopenfilename(initialdir = "/Program Files/Unity/Hub/Editor", title = "choose unity editor",filetypes = (("Editor","Unity.exe"),("all files","*.*")))
+
+    yaml_data['unity_editor_filename'] = filename
+    if filename == '':
+        raise Exception('No Editor Selected!')
+
+    with open(config_filename, 'w') as outfile:
+        yaml.dump(yaml_data, outfile, default_flow_style=False)
+
+unity_editor_filename = yaml_data['unity_editor_filename']
+asset_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+
+project_directory = os.path.abspath(os.path.join(asset_directory, os.pardir))
+library_path = project_directory + '\\Assets\\' + yaml_data['c_libs_asset_path']
+
+if not (library_path in os.environ['PATH']):
+    os.environ['PATH'] = os.environ['PATH'] + ';' + library_path + ';'
+
+subprocess.call([unity_editor_filename, '-projectPath', project_directory])
+
+

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.py
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_editor.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import yaml
 import argparse
+import platform
 
 from tkinter.filedialog import askopenfilename
 
@@ -15,10 +16,16 @@ args = parser.parse_args()
 config_filename = 'ros_config.yaml'
 
 # Defaults
-yaml_data = {
-    'unity_editor_filename': None,
-    'c_libs_asset_path': 'Plugins\\x86_64'
-}
+if platform.system() == 'Windows':
+    yaml_data = {
+        'unity_editor_filename': None,
+        'c_libs_asset_path': 'Plugins\\x86_64'
+    }
+else:
+    yaml_data = {
+        'unity_editor_filename': None,
+        'c_libs_asset_path': 'Plugins/x86_64'
+    }
 
 if os.path.isfile(config_filename):
     with open(config_filename) as stream:
@@ -32,7 +39,16 @@ else:
         yaml.dump(yaml_data, outfile, default_flow_style=False)
 
 if yaml_data['unity_editor_filename'] == None or args.select_editor:
-    filename =  askopenfilename(initialdir = "/Program Files/Unity/Hub/Editor", title = "choose unity editor",filetypes = (("Editor","Unity.exe"),("all files","*.*")))
+    if platform.system() == 'Windows':
+        default_editor_folder = "/Program Files/Unity/Hub/Editor"
+        editor_filetype = "Unity.exe"
+    else:
+        default_editor_folder = "~/Unity/Hub/Editor"
+        editor_filetype = "Unity"
+
+    filename =  askopenfilename(initialdir = default_editor_folder,
+                                title = "choose unity editor",
+                                filetypes = (("Editor", editor_filetype),("all files","*.*")))
 
     yaml_data['unity_editor_filename'] = filename
     if filename == '':
@@ -45,11 +61,20 @@ unity_editor_filename = yaml_data['unity_editor_filename']
 asset_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
 
 project_directory = os.path.abspath(os.path.join(asset_directory, os.pardir))
-library_path = project_directory + '\\Assets\\' + yaml_data['c_libs_asset_path']
 
-if not (library_path in os.environ['PATH']):
-    os.environ['PATH'] = os.environ['PATH'] + ';' + library_path + ';'
+if platform.system() == 'Windows':
+    library_path = project_directory + '\\Assets\\' + yaml_data['c_libs_asset_path']
+    if not (library_path in os.environ['PATH']):
+        os.environ['PATH'] = os.environ['PATH'] + ';' + library_path + ';'
+else:
+    library_path = project_directory + '/Assets/' + yaml_data['c_libs_asset_path']
+    if 'LD_LIBRARY_PATH' in os.environ:
+        os.environ['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH'] + ':' + library_path
+    else:
+        os.environ['LD_LIBRARY_PATH'] = library_path
+
+    if not (library_path in os.environ['PATH']):
+        os.environ['PATH'] = os.environ['PATH'] + ':' + library_path
+
 
 subprocess.call([unity_editor_filename, '-projectPath', project_directory])
-
-

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_player.bash
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_player.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python3 start_player.py

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_player.bat
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_player.bat
@@ -1,0 +1,1 @@
+python start_player.py

--- a/rcldotnet_utils/rcldotnet_utils/unity_files/start_player.py
+++ b/rcldotnet_utils/rcldotnet_utils/unity_files/start_player.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import subprocess
+import platform
+
+build_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+
+if platform.system() == 'Windows':
+    library_path = build_directory + '\\BuiltGame_Data\\Plugins'
+    if not (library_path in os.environ['PATH']):
+        os.environ['PATH'] = os.environ['PATH'] + ';' + library_path
+else:
+    library_path = build_directory + '/BuiltGame_Data/Plugins'
+    if 'LD_LIBRARY_PATH' in os.environ:
+        os.environ['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH'] + ':' + library_path
+    else:
+        os.environ['LD_LIBRARY_PATH'] = library_path
+
+
+if platform.system() == 'Windows':
+    subprocess.call(['BuiltGame.exe'])
+else:
+    player_directory = os.path.dirname(os.path.realpath(sys.argv[0]))
+    player_path = player_directory + '/BuiltGame'
+    print("Binary path: " + player_path)
+    subprocess.call([player_path])

--- a/rcldotnet_utils/setup.cfg
+++ b/rcldotnet_utils/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/rcldotnet_utils
+[install]
+install-scripts=$base/lib/rcldotnet_utils

--- a/rcldotnet_utils/setup.py
+++ b/rcldotnet_utils/setup.py
@@ -1,0 +1,35 @@
+from setuptools import find_packages
+from setuptools import setup
+package_name = 'rcldotnet_utils'
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    author='Samuel Lindgren',
+    author_email='samuel@dynorobotics.se',
+    maintainer='Samuel Lindgren',
+    maintainer_email='samuel@dynorobotics.se',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache License 2.0',
+        'Programming Language :: Python',
+    ],
+    description=(
+        'Utility scripts for rlcdotnet'
+    ),
+    license='Apache Licence 2.0',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'init_unity_project = rcldotnet_utils.init_unity_project:main'
+        ],
+    },
+)

--- a/ros2_dotnet_dashing.repos
+++ b/ros2_dotnet_dashing.repos
@@ -1,16 +1,5 @@
 ﻿repositories:
-  ros2/common_interfaces:
-    type: git
-    url: https://github.com/ros2/common_interfaces.git
-    version: dashing
-  ros2/unique_identifier_msgs:
-    type: git
-    url: https://github.com/ros2/unique_identifier_msgs.git
-    version: dashing
-  ros2/rcl_interfaces:
-    type: git
-    url: https://github.com/ros2/rcl_interfaces.git
-    version: dashing
+  # rcldotnet
   ros2/rosidl_defaults:
     type: git
     url: https://github.com/ros2/rosidl_defaults.git
@@ -27,3 +16,20 @@
     type: git
     url: https://github.com/adamdbrw/ros2_dotnet.git
     version: master
+  # messages
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: dashing
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: dashing
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: dashing
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: dashing

--- a/ros2_dotnet_dashing_standalone.repos
+++ b/ros2_dotnet_dashing_standalone.repos
@@ -1,0 +1,227 @@
+repositories:
+
+  # rcldotnet
+  ament_dotnet/ament_cmake_export_assemblies:
+    type: git
+    url: https://github.com/esteve/ament_cmake_export_assemblies.git
+    version: master
+  ros2_dotnet/dotnet_cmake_module:
+    type: git
+    url: https://github.com/esteve/dotnet_cmake_module.git
+    version: master
+  ros2_dotnet/ros2_dotnet:
+    type: git
+    url: https://github.com/samiamlabs/ros2_dotnet.git
+    version: master
+
+  # messages
+  ros2/common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: dashing
+  ros2/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: ros2
+  ros2/unique_identifier_msgs:
+    type: git
+    url: https://github.com/ros2/unique_identifier_msgs.git
+    version: dashing
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: dashing
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: dashing
+  ros2/test_interface_files:
+    type: git
+    url: https://github.com/ros2/test_interface_files.git
+    version: dashing
+
+  # minimal ros2
+  ament/ament_cmake:
+    type: git
+    url: https://github.com/ament/ament_cmake.git
+    version: dashing
+  ament/ament_index:
+    type: git
+    url: https://github.com/ament/ament_index.git
+    version: dashing
+  ament/ament_lint:
+    type: git
+    url: https://github.com/ament/ament_lint.git
+    version: dashing
+  ament/ament_package:
+    type: git
+    url: https://github.com/ament/ament_package.git
+    version: dashing
+  ament/googletest:
+    type: git
+    url: https://github.com/ament/googletest.git
+    version: dashing
+  ament/uncrustify_vendor:
+    type: git
+    url: https://github.com/ament/uncrustify_vendor.git
+    version: dashing
+  eProsima/Fast-CDR:
+    type: git
+    url: https://github.com/eProsima/Fast-CDR.git
+    version: 906c966c426f85d503baca9c2e46bead7b633dff
+  eProsima/Fast-RTPS:
+    type: git
+    url: https://github.com/eProsima/Fast-RTPS.git
+    version: 6a6f79c4256a00fc13834a2aaa3c60a0aaac5e76
+  osrf/osrf_testing_tools_cpp:
+    type: git
+    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+    version: dashing
+  # ros/class_loader:
+  #   type: git
+  #   url: https://github.com/ros/class_loader.git
+  #   version: dashing
+  # ros/pluginlib:
+  #   type: git
+  #   url: https://github.com/ros/pluginlib.git
+  #   version: dashing
+  # ros/resource_retriever:
+  #   type: git
+  #   url: https://github.com/ros/resource_retriever.git
+  #   version: dashing
+  # ros/ros_environment:
+  #   type: git
+  #   url: https://github.com/ros/ros_environment.git
+  #   version: dashing
+  # ros/urdfdom_headers:
+  #   type: git
+  #   url: https://github.com/ros/urdfdom_headers.git
+  #   version: dashing
+  ros2/ament_cmake_ros:
+    type: git
+    url: https://github.com/ros2/ament_cmake_ros.git
+    version: dashing
+  # ros2/console_bridge_vendor:
+  #   type: git
+  #   url: https://github.com/ros2/console_bridge_vendor.git
+  #   version: dashing
+  # ros2/kdl_parser:
+  #   type: git
+  #   url: https://github.com/ros2/kdl_parser.git
+  #   version: dashing
+  ros2/launch:
+    type: git
+    url: https://github.com/ros2/launch.git
+    version: dashing
+  # ros2/launch_ros:
+  #   type: git
+  #   url: https://github.com/ros2/launch_ros.git
+  #   version: dashing
+  ros2/libyaml_vendor:
+    type: git
+    url: https://github.com/ros2/libyaml_vendor.git
+    version: dashing
+  ros2/poco_vendor:
+    type: git
+    url: https://github.com/ros2/poco_vendor.git
+    version: dashing
+  ros2/rcl:
+    type: git
+    url: https://github.com/ros2/rcl.git
+    version: dashing
+  ros2/rcl_interfaces:
+    type: git
+    url: https://github.com/ros2/rcl_interfaces.git
+    version: dashing
+  ros2/rcl_logging:
+    type: git
+    url: https://github.com/ros2/rcl_logging.git
+    version: dashing
+  ros2/rclpy:
+    type: git
+    url: https://github.com/ros2/rclpy.git
+    version: dashing
+  ros2/rcutils:
+    type: git
+    url: https://github.com/ros2/rcutils.git
+    version: dashing
+  ros2/rcpputils:
+    type: git
+    url: https://github.com/ros2/rcpputils.git
+    version: dashing
+  # ros2/realtime_support:
+  #   type: git
+  #   url: https://github.com/ros2/realtime_support.git
+  #   version: dashing
+  ros2/rmw:
+    type: git
+    url: https://github.com/ros2/rmw.git
+    version: dashing
+  ros2/rmw_fastrtps:
+    type: git
+    url: https://github.com/ros2/rmw_fastrtps.git
+    version: dashing
+  ros2/rmw_implementation:
+    type: git
+    url: https://github.com/ros2/rmw_implementation.git
+    version: dashing
+  # ros2/ros_testing:
+  #   type: git
+  #   url: https://github.com/ros2/ros_testing.git
+  #   version: dashing
+  ros2/ros2cli:
+    type: git
+    url: https://github.com/ros2/ros2cli.git
+    version: dashing
+  ros2/rosidl:
+    type: git
+    url: https://github.com/ros2/rosidl.git
+    version: dashing
+  ros2/rosidl_defaults:
+    type: git
+    url: https://github.com/ros2/rosidl_defaults.git
+    version: dashing
+  ros2/rosidl_python:
+    type: git
+    url: https://github.com/ros2/rosidl_python.git
+    version: dashing
+  ros2/rosidl_typesupport:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport.git
+    version: dashing
+  ros2/rosidl_typesupport_fastrtps:
+    type: git
+    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+    version: dashing
+  # ros2/sros2:
+  #   type: git
+  #   url: https://github.com/ros2/sros2.git
+  #   version: dashing
+  # ros2/system_tests:
+  #   type: git
+  #   url: https://github.com/ros2/system_tests.git
+  #   version: dashing
+  ros2/tinydir_vendor:
+    type: git
+    url: https://github.com/ros2/tinydir_vendor.git
+    version: dashing
+  # ros2/tinyxml2_vendor:
+  #   type: git
+  #   url: https://github.com/ros2/tinyxml2_vendor.git
+  #   version: dashing
+  # ros2/tinyxml_vendor:
+  #   type: git
+  #   url: https://github.com/ros2/tinyxml_vendor.git
+  #   version: dashing
+  # ros2/tlsf:
+  #   type: git
+  #   url: https://github.com/ros2/tlsf.git
+  #   version: dashing
+  # ros2/urdf:
+  #   type: git
+  #   url: https://github.com/ros2/urdf.git
+  #   version: dashing
+  # ros2/urdfdom:
+  #   type: git
+  #   url: https://github.com/ros2/urdfdom.git
+  #   version: dashing

--- a/ros2_dotnet_dashing_standalone.repos
+++ b/ros2_dotnet_dashing_standalone.repos
@@ -22,7 +22,7 @@ repositories:
   ros2/geometry2:
     type: git
     url: https://github.com/ros2/geometry2.git
-    version: ros2
+    version: dashing
   ros2/unique_identifier_msgs:
     type: git
     url: https://github.com/ros2/unique_identifier_msgs.git
@@ -77,10 +77,10 @@ repositories:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
     version: dashing
-  # ros/class_loader:
-  #   type: git
-  #   url: https://github.com/ros/class_loader.git
-  #   version: dashing
+  ros/class_loader:
+    type: git
+    url: https://github.com/ros/class_loader.git
+    version: dashing
   # ros/pluginlib:
   #   type: git
   #   url: https://github.com/ros/pluginlib.git
@@ -101,10 +101,22 @@ repositories:
     type: git
     url: https://github.com/ros2/ament_cmake_ros.git
     version: dashing
-  # ros2/console_bridge_vendor:
-  #   type: git
-  #   url: https://github.com/ros2/console_bridge_vendor.git
-  #   version: dashing
+  ros2/console_bridge_vendor:
+    type: git
+    url: https://github.com/ros2/console_bridge_vendor.git
+    version: dashing
+  ros2/eigen3_cmake_module:
+    type: git
+    url: https://github.com/ros2/eigen3_cmake_module.git
+    version: dashing
+  ros2/message_filters:
+    type: git
+    url: https://github.com/ros2/message_filters.git
+    version: dashing
+  ros2/orocos_kinematics_dynamics:
+    type: git
+    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+    version: dashing
   # ros2/kdl_parser:
   #   type: git
   #   url: https://github.com/ros2/kdl_parser.git
@@ -132,6 +144,10 @@ repositories:
   ros2/rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
+    version: dashing
+  ros2/rclcpp:
+    type: git
+    url: https://github.com/ros2/rclcpp.git
     version: dashing
   ros2/rcl_logging:
     type: git


### PR DESCRIPTION
Hi Adam.

The utility script ( `ros2 run rcldotnet_utils init_unity_project` )can create "standalone" Unity projects for Windows and Linux. This approach requires that both player (app) and editor is started using the automatically added scripts that set env-vars and starts the editor without UnityHub.

Both player and editor work with ROS2 from plugin directory on Windows 10. On Linux the standalone player works, but the editor still crashes when pressing play for some reason. Have not figured out why yet. Only tested on Unity 2019.2.0f1 so far.

I rebased a couple of days ago and got all the tests to pass (added back most message tests and wrote some new ones).
After merging the newest changes today, there were some new failing tests that are a bit concerning.
Will dump the test log below.

The changes to message Interface name and the redesign of nested seems to be working fine :) I did not implement a set function before because I was worried about memory leaks when changing them. I saw a commit message indicating that you fixed some problems relating to that. Have you checked if there still are any leaks now using a tool or something?

I noticed that you changed from Lists to Arrays for messages as well. Was that for performance reasons? Have already updated my Unity side code to use Arrays btw, so just asking because I'm curious about why :)

I think we should fix the failing tests before putting this pull request on main. Only the master branch on my branch is running automatic CI now, right? Was not able to add your repo to CircleCI because of permissions.